### PR TITLE
fix typo & apply code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ This is a sample docker for creating REST API machine learning services
 
 To install and run:
 
-- $ git clone git@github.com:cecile/docker-ml-api.git
-- $ cd docker-ml=api
-- $ docker build -t ml-api
-- $ docker run -d -p 80:8080 ml-api
+- `git clone git@github.com:cecile/docker-ml-api.git`
+- `cd docker-ml-api`
+- `docker build -t ml-api`
+- `docker run -d -p 80:8080 ml-api`
 
 Blog entry with a walktrought of this example:
 


### PR DESCRIPTION
- change from `cd docker-ml=api` to `cd docker-ml-api`
- wrap command line steps in ticks, to apply markdown formatting